### PR TITLE
Updated Go-SDK to support IRSA

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ministryofjustice/prometheus_ecr_exporter
 go 1.12
 
 require (
-	github.com/aws/aws-sdk-go v1.20.8
+	github.com/aws/aws-sdk-go v1.23.13
 	github.com/prometheus/client_golang v1.0.0
 	golang.org/x/text v0.3.2 // indirect
 )


### PR DESCRIPTION
In order to support IRSA (IAM Roles for Service Accounts), we need to be using at least v1.23.13 of the Go SDK ([as specified in the documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html)). This will allow us to use ECR exporter in EKS without using KIAM/Kube2IAM